### PR TITLE
add Quadro RTX 4000 8GB

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -62,6 +62,11 @@
         "interface": "SXM2",
         "memory_size": "32Gi"
       },
+      "1eb1": {
+        "name": "rtx4000",
+        "interface": "PCIe",
+        "memory_size": "8Gi"
+      },
       "1e30": {
         "name": "rtx8000",
         "interface": "PCIe",


### PR DESCRIPTION
```
root@node1:~# nvidia-smi -L
GPU 0: Quadro RTX 4000 (UUID: GPU-c7b57be0-94ff-d352-a59b-d0ee00aeed43)
GPU 1: Quadro RTX 4000 (UUID: GPU-d6de6afc-bdfe-75c4-5273-0544439153fc)

root@node1:~# nvidia-smi
Thu Feb 29 14:58:21 2024       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.129.03             Driver Version: 535.129.03   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Quadro RTX 4000                Off | 00000000:06:00.0 Off |                  N/A |
| 30%   25C    P8              10W / 125W |      1MiB /  8192MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   1  Quadro RTX 4000                Off | 00000000:07:00.0 Off |                  N/A |
| 30%   25C    P8               1W / 125W |      1MiB /  8192MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
                                                                                         
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
```

```
root@node1:~# provider-services-0.5.0-rc1 operator psutil list gpu | jq '.cards[] | .pci | {vendor: .vendor, produc: .product}'
{
  "vendor": {
    "id": "10de",
    "name": "NVIDIA Corporation"
  },
  "produc": {
    "id": "1eb1",
    "name": "TU104GL [Quadro RTX 4000]"
  }
}
{
  "vendor": {
    "id": "10de",
    "name": "NVIDIA Corporation"
  },
  "produc": {
    "id": "1eb1",
    "name": "TU104GL [Quadro RTX 4000]"
  }
}
```

```
root@node1:~# provider-services-0.5.0-rc1 operator psutil list gpu | jq '.cards[] | .pci | {vendor: .vendor, product: .product}'
{
  "vendor": {
    "id": "10de",
    "name": "NVIDIA Corporation"
  },
  "product": {
    "id": "1eb1",
    "name": "TU104GL [Quadro RTX 4000]"
  }
}
{
  "vendor": {
    "id": "10de",
    "name": "NVIDIA Corporation"
  },
  "product": {
    "id": "1eb1",
    "name": "TU104GL [Quadro RTX 4000]"
  }
}
```