### PR TITLE
workaround: add support for RTX 4090 GPUs with subsystem vendor ID 10b0 (CardExpert Technology)

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -1,4 +1,14 @@
 {
+  "10b0": {
+    "name": "nvidia",
+    "devices": {
+      "2684": {
+        "name": "rtx4090",
+        "interface": "PCIe",
+        "memory_size": "24Gi"
+      }
+    }
+  },
   "10de": {
     "name": "nvidia",
     "devices": {


### PR DESCRIPTION
Some RTX 4090 GPUs—such as those manufactured by CardExpert or other AIB partners—report a **Subsystem Vendor ID** of `10b0` instead of the expected `10de` (NVIDIA Corporation). Because of this, `akash-inventory-operator` fails to detect the GPU, and the required `nvidia.com/gpu.present=true` label is not applied to the node. This prevents the NVIDIA device plugin (NVDP) from scheduling GPU workloads, even though the GPU is fully functional and visible in `lspci`.

This patch works around the issue by adding a new `10b0` vendor entry in `gpus.json`, mapping Product ID `2684` to the RTX 4090. This enables proper detection and labeling without requiring hardware modifications or changes to `provider-services`.

> Detection is based solely on **Vendor ID** and **Product ID**, and does not evaluate the **Subsystem Vendor ID** or **Subsystem Device ID**, as confirmed in:
> https://github.com/akash-network/provider/blob/v0.6.11-rc1/operator/inventory/node-discovery.go#L942-L950

This workaround is effective for now, but a more robust long-term solution would be to update `akash-inventory-operator` (and `provider-services psutil`) to ignore the **Subsystem Vendor ID** entirely and rely only on the primary PCI Vendor and Device IDs.

Ref: https://github.com/akash-network/support/issues/298