### PR TITLE
fix: update 10b0 entry to use Subsystem Device ID f297 for RTX 4090 detection

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -2,7 +2,7 @@
   "10b0": {
     "name": "nvidia",
     "devices": {
-      "2684": {
+      "f297": {
         "name": "rtx4090",
         "interface": "PCIe",
         "memory_size": "24Gi"


### PR DESCRIPTION
The previous entry under vendor `10b0` used Product ID `2684`, which reflects the primary PCI device ID. This patch updates `gpus.json` to match the format currently used by the inventory operator, enabling proper detection and labeling of affected RTX 4090 GPUs.

Ref: https://github.com/akash-network/support/issues/298