### PR TITLE
Add RTX 5070 GPU to gpus.json

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -456,6 +456,10 @@
         "name": "mi100",
         "interface": "PCIe",
         "memory_size": "32Gi"
+      }"2f04": {
+        "name": "rtx5070",
+        "interface": "PCIe",
+        "memory_size": "12Gi"
       }
     }
   }

--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -442,6 +442,11 @@
         "interface": "PCIe",
         "memory_size": "141Gi"
       }
+      "2f04": {
+        "name": "rtx5070",
+        "interface": "PCIe",
+        "memory_size": "12Gi"
+      }
     }
   },
   "1002": {
@@ -456,10 +461,6 @@
         "name": "mi100",
         "interface": "PCIe",
         "memory_size": "32Gi"
-      }"2f04": {
-        "name": "rtx5070",
-        "interface": "PCIe",
-        "memory_size": "12Gi"
       }
     }
   }


### PR DESCRIPTION
provider-services tools psutil list gpu
{
  "cards": [
    {
      "address": "0000:02:00.0",
      "index": 1,
      "pci": {
        "driver": "nvidia",
        "address": "0000:02:00.0",
        "vendor": {
          "id": "10de",
          "name": "NVIDIA Corporation"
        },
        "product": {
          "id": "2f04",
          "name": "unknown"
        },
        "revision": "0xa1",
        "subsystem": {
          "id": "417e",
          "name": "unknown"
        },
        "class": {
          "id": "03",
          "name": "Display controller"
        },
        "subclass": {
          "id": "00",
          "name": "VGA compatible controller"
        },
        "programming_interface": {
          "id": "00",
          "name": "VGA controller"
        }
      }
    }
  ]
}