### PR TITLE
Add new GPU entry for rtx5070 in gpus.json

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -247,6 +247,11 @@
         "interface": "PCIe",
         "memory_size": "24Gi"
       },
+      "2f04": {
+        "name": "rtx5070",
+        "interface": "PCIe",
+        "memory_size": "12Gi"
+      },
       "2c02": {
         "name": "rtx5080",
         "interface": "PCIe",
@@ -442,6 +447,7 @@
         "interface": "PCIe",
         "memory_size": "141Gi"
       }
+      
     }
   },
   "1002": {


### PR DESCRIPTION
provider-services tools psutil list gpu
{
  "cards": [
    {
      "address": "0000:02:00.0",
      "index": 1,
      "pci": {
        "driver": "nvidia",
        "address": "0000:02:00.0",
        "vendor": {
          "id": "10de",
          "name": "NVIDIA Corporation"
        },
        "product": {
          "id": "2f04",
          "name": "unknown"
        },
        "revision": "0xa1",
        "subsystem": {
          "id": "417e",
          "name": "unknown"
        },
        "class": {
          "id": "03",
          "name": "Display controller"
        },
        "subclass": {
          "id": "00",
          "name": "VGA compatible controller"
        },
        "programming_interface": {
          "id": "00",
          "name": "VGA controller"
        }
      }
    }
  ]
}