### PR TITLE
Add GPU: RTX A5000 (10de:2231)

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -451,6 +451,11 @@
         "name": "h200nvl",
         "interface": "PCIe",
         "memory_size": "141Gi"
+      },
+      "2231": {
+        "name": "a5000",
+        "interface": "PCIe",
+        "memory_size": "24Gi"
       }
       
     }


### PR DESCRIPTION
Fixes #82

Vendor ID: 10de
Device ID: 2231
Model: GA102GL [RTX A5000]
Memory: 24Gi
Interface: PCIe

nvidia-smi: NVIDIA RTX A5000, 24564 MiB, 570.211.01, 0x223110DE