### PR TITLE
Add RTX 3060 device ID 2503 in gpus.json

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -157,6 +157,11 @@
         "interface": "PCIe",
         "memory_size": "12Gi"
       },
+      "2503": {
+        "name": "rtx3060",
+        "interface": "PCIe",
+        "memory_size": "12Gi"
+      },
       "2504": {
         "name": "rtx3060",
         "interface": "PCIe",


### PR DESCRIPTION
Adds missing NVIDIA RTX 3060 PCI device ID `2503`.

Detected hardware:

```text
03:00.0 VGA compatible controller [0300]: NVIDIA Corporation GA106 [GeForce RTX 3060] [10de:2503] (rev a1)