### PR TITLE
Add RTX 3060M device ID 2560 in gpus.json

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -168,7 +168,7 @@
         "memory_size": "12Gi"
       },
       "2520": {
-        "name": "rtx3060m2",
+        "name": "rtx3060m",
         "interface": "PCIe",
         "memory_size": "6Gi"
       },

--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -168,6 +168,11 @@
         "memory_size": "12Gi"
       },
       "2520": {
+        "name": "rtx3060m2",
+        "interface": "PCIe",
+        "memory_size": "6Gi"
+      },
+      "2560": {
         "name": "rtx3060m",
         "interface": "PCIe",
         "memory_size": "6Gi"


### PR DESCRIPTION
Hardware-discovery on an Akash homenode reports PCI ID `10de:2560` as `GA106M [GeForce RTX 3060 Mobile / Max-Q]`, but the database does not have an entry for it. Both `10de:2520` and `10de:2560` are RTX 3060 Mobile silicon variants — adds `2560` with the same `rtx3060m` name, 6Gi memory, PCIe interface.