### PR TITLE
Add NVIDIA RTX 5060 Ti PCI ID 2d04

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -262,6 +262,11 @@
         "interface": "PCIe",
         "memory_size": "24Gi"
       },
+      "2d04":{
+        "name": "rtx5060ti",
+        "interface": "PCIe",
+        "memory_size": "16Gi"
+      },
       "2f04": {
         "name": "rtx5070",
         "interface": "PCIe",


### PR DESCRIPTION
Adds NVIDIA GeForce RTX 5060 Ti 16GB PCI device ID.

GPU: NVIDIA GeForce RTX 5060 Ti
Vendor ID: 10de
Device ID: 2d04
Subsystem: 1462:5354 MSI
Memory: 16Gi

Observed:
- nvidia-smi reports NVIDIA GeForce RTX 5060 Ti with 16311MiB
- lspci reports NVIDIA Corporation Device [10de:2d04]
- provider-services tools psutil list gpu currently reports product.name as unknown
- Akash inventory reports gpu_info as null