### PR TITLE
Add GPU: RTX 5090 Laptop (rtx5090m)

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -277,6 +277,11 @@
         "interface": "PCIe",
         "memory_size": "32Gi"
       },
+      "2c58": {
+        "name": "rtx5090m",
+        "interface": "PCIe",
+        "memory_size": "24Gi"
+      },
       "13f1": {
         "name": "m4000",
         "interface": "PCIe",


### PR DESCRIPTION
## Summary

Adds the **NVIDIA GeForce RTX 5090 Laptop GPU** to the GPU database.

| Field | Value |
|-------|-------|
| Vendor | `10de` (NVIDIA) |
| Device | `2c58` |
| Name | `rtx5090m` |
| Interface | `PCIe` |
| Memory | `24Gi` |

Named `rtx5090m` (mobile suffix) to follow the existing laptop-variant convention (e.g. `rtx3060m`) and to stay distinct from the desktop `rtx5090` at device `2b85`.

## Device detection

`Get-PnpDevice -Class Display | Select-Object FriendlyName, InstanceId`:

```
FriendlyName                         InstanceId
------------                         ----------
NVIDIA GeForce RTX 5090 Laptop GPU   PCI\VEN_10DE&DEV_2C58&SUBSYS_30111A58&REV_A1\B73A356AA12DB04800
```

`PCI\VEN_10DE&DEV_2C58` → vendor `10de`, device `2c58`.