### PR TITLE
Add NVIDIA Tesla V100 PCIe 32GB (10de:1df0)

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -407,6 +407,11 @@
         "interface": "SXM3",
         "memory_size": "32Gi"
       },
+      "1df0": {
+        "name": "v100",
+        "interface": "PCIe",
+        "memory_size": "32Gi"
+      },
       "2235": {
         "name": "a40",
         "interface": "PCIe",


### PR DESCRIPTION
## Summary
Adds the PCI device id `10de:1df0` (NVIDIA `GV100GL [Tesla PG500-216]`) to `devices/pcie/gpus.json` as a Volta **V100**, PCIe interface, 32 GiB.

## Why
This board ships in some V100 systems but its device id (`1df0`) is not in the list — only the SXM variants (`1db1`/`1db5`/`1db8`) are present. As a result, `operator-inventory` resolves `gpu.info = null` for nodes carrying this card, so the GPU is never advertised in provider inventory (and, with the inventory liveness check, can restart-loop the operator).

## Verification
On real hardware:
```
$ nvidia-smi --query-gpu=name,memory.total,pci.device_id --format=csv,noheader
Tesla PG500-216, 32768 MiB, 0x1DF010DE
```
`lspci`: `3D controller: NVIDIA Corporation GV100GL [Tesla PG500-216] [10de:1df0]` — PCIe, 32 GiB HBM2, which matches the existing `v100` / `32Gi` entries.

## Change
```json
"1df0": {
  "name": "v100",
  "interface": "PCIe",
  "memory_size": "32Gi"
}
```