### PR TITLE
Add GPU: H100 NVL (h100nvl)

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -467,6 +467,11 @@
         "interface": "PCIe",
         "memory_size": "80Gi"
       },
+      "2321": {
+        "name": "h100nvl",
+        "interface": "PCIe",
+        "memory_size": "94Gi"
+      },
       "2335": {
         "name": "h200",
         "interface": "SXM5",


### PR DESCRIPTION
## Summary

Adds the **NVIDIA H100 NVL GPU** to the GPU database.

| Field | Value |
|-------|-------|
| Vendor | `10de` (NVIDIA) |
| Device | `2321` |
| Name | `h100nvl` |
| Interface | `PCIe` |
| Memory | `94Gi` |

Named `h100nvl` (NVLink suffix) to stay distinct from the standard H100 PCIe (`2331`, 80Gi). The H100 NVL is a two-GPU NVLink configuration with 94 GiB of HBM3 memory per GPU.

## Device detection

`nvidia-smi --query-gpu=name,pci.device_id --format=csv,noheader`:

```
NVIDIA H100 NVL, 0x232110DE
```

`PCI\VEN_10DE&DEV_2321` → vendor `10de`, device `2321`.