### PR TITLE
feat: add next-gen NVIDIA Ada/Blackwell DC and AMD MI200/MI300 series GPUs

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -481,8 +481,22 @@
         "name": "a5000",
         "interface": "PCIe",
         "memory_size": "24Gi"
+      },
+      "27b8": {
+        "name": "l4",
+        "interface": "PCIe",
+        "memory_size": "24Gi"
+      },
+      "26b9": {
+        "name": "l40s",
+        "interface": "PCIe",
+        "memory_size": "48Gi"
+      },
+      "2901": {
+        "name": "b200",
+        "interface": "SXM6",
+        "memory_size": "192Gi"
       }
-      
     }
   },
   "1002": {
@@ -497,6 +511,31 @@
         "name": "mi100",
         "interface": "PCIe",
         "memory_size": "32Gi"
+      },
+      "740c": {
+        "name": "mi250x",
+        "interface": "OAM",
+        "memory_size": "128Gi"
+      },
+      "74a0": {
+        "name": "mi300a",
+        "interface": "OAM",
+        "memory_size": "128Gi"
+      },
+      "74a1": {
+        "name": "mi300x",
+        "interface": "OAM",
+        "memory_size": "192Gi"
+      },
+      "74a5": {
+        "name": "mi325x",
+        "interface": "OAM",
+        "memory_size": "256Gi"
+      },
+      "75a0": {
+        "name": "mi350x",
+        "interface": "OAM",
+        "memory_size": "288Gi"
       }
     }
   }

--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -526,16 +526,6 @@
         "name": "mi300x",
         "interface": "OAM",
         "memory_size": "192Gi"
-      },
-      "74a5": {
-        "name": "mi325x",
-        "interface": "OAM",
-        "memory_size": "256Gi"
-      },
-      "75a0": {
-        "name": "mi350x",
-        "interface": "OAM",
-        "memory_size": "288Gi"
       }
     }
   }


### PR DESCRIPTION
## Summary

This PR adds **6 missing high-demand GPU PCI device IDs** to `devices/pcie/gpus.json` — covering NVIDIA's Ada Lovelace data-center line, the new Blackwell B200, and AMD's Instinct MI250X/MI300 series. This adds first-class support for these GPUs on Akash, enabling providers running them to be correctly identified and discoverable by tenants.

All 6 entries have been verified against official driver documentation or direct `lspci` output from hardware.

---

## NVIDIA additions (`10de`)

| Device ID | Name | Interface | Memory | Notes |
|-----------|------|-----------|--------|-------|
| `27b8` | `l4` | PCIe | 24Gi | Ada Lovelace inference/video accelerator — confirmed via [NVIDIA developer forums](https://forums.developer.nvidia.com/t/problem-installing-nvidia-driver-for-nvidia-l4-gpu/284374) and [NVIDIA driver README Appendix A](https://download.nvidia.com/solaris/575.57.08/README/supportedchips.html) |
| `26b9` | `l40s` | PCIe | 48Gi | Ada Lovelace do-it-all DC GPU — `[10de:26b9]` confirmed via [Ubuntu driver forums lspci output](https://forums.developer.nvidia.com/t/ubuntu-server-22-0-4-lts-not-always-recognizing-all-l40s-gpus/271891) and [PCI device database](https://devicehunt.com/view/type/pci/vendor/10DE) |
| `2901` | `b200` | SXM6 | 192Gi | Blackwell HGX B200 — `[10de:2901]` confirmed via [NVIDIA driver README](https://download.nvidia.com/solaris/575.57.08/README/supportedchips.html), [Supermicro FAQ](https://www.supermicro.com/en/support/faqs/faq.php?faq=43497), [Ubuntu certified component](https://ubuntu.com/certified/component/1021), and [Oracle real lspci log](https://blogs.oracle.com/linux/gpu-confidential-computing-ol9). Interface is `SXM6` (HGX board-level module), consistent with how the repo uses `SXM2`/`SXM3`/`SXM4`/`SXM5` for other NVIDIA accelerators. |

---

## AMD additions (`1002`)

| Device ID | Name | Interface | Memory | Notes |
|-----------|------|-----------|--------|-------|
| `740c` | `mi250x` | OAM | 128Gi | CDNA2 Aldebaran — PCI ID confirmed via [AMD ROCm system-acceptance docs](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/gpus/mi250.html): `sudo lspci -d 1002:740c`. Memory: 128 GB HBM2e per OAM module. |
| `74a0` | `mi300a` | OAM | 128Gi | CDNA3 APU (CPU+GPU) — PCI ID confirmed via [AMD ROCm system-acceptance docs](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/gpus/mi300a.html): `sudo lspci -d 1002:74a0`. Memory: 128 GB unified HBM3. |
| `74a1` | `mi300x` | OAM | 192Gi | CDNA3 AI accelerator — 192 GB HBM3 per [AMD MI300X platform datasheet](https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-platform-data-sheet.pdf). Heavily demanded for large LLM workloads. |

---

## Relation to other open PRs

- **This PR is independent of PR #91** (`add-h100nvl-gpu-config` by @fenilmodi00) — different device IDs, no file conflicts.
- **This PR defers to PR #88** for RTX 5060 Ti (`2d04`) — no conflict.

---

## Testing

Device IDs verified against:
- NVIDIA official driver README (Appendix A supported chips list) for all three NVIDIA IDs
- AMD ROCm system-acceptance documentation with explicit `lspci -d` commands for `740c` and `74a0`
- AMD MI300X platform datasheet and OEM server guides for `74a1`

JSON validated: well-formed, no duplicate keys, consistent formatting with existing file.