### PR TITLE
Update fix-rtx8000-subsystem gpus.json

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -335,7 +335,13 @@
       "1e30": {
         "name": "rtx6000",
         "interface": "PCIe",
-        "memory_size": "24Gi"
+        "memory_size": "24Gi",
+        "subsystems": {
+          "129e": {
+            "name": "rtx8000",
+            "memory_size": "48Gi"
+          }
+        }
       },
       "1e78": {
         "name": "rtx8000",


### PR DESCRIPTION
### Description
This PR introduces a PCIe subsystem exception for a specific variant of the NVIDIA RTX 8000. 

Currently, this specific hardware revision identifies itself on the PCI bus with Product ID `1e30`, which is globally mapped to the RTX 6000 (24Gi VRAM). However, this specific model carries Subsystem ID `129e` and contains 48Gi of VRAM (RTX 8000).

Nesting this exception under the `subsystems` array for device `1e30` ensures that the `akash-inventory-operator` correctly recognizes the 48Gi VRAM capacity instead of mislabeling it as a 24Gi RTX 6000.

### Proposed Changes in `devices/pcie/gpus.json`
```json
      "1e30": {
        "name": "rtx6000",
        "interface": "PCIe",
        "memory_size": "24Gi",
        "subsystems": {
          "129e": {
            "name": "rtx8000",
            "memory_size": "48Gi"
          }
        }
      },
```

### GPU Tool Output
```json
{
  "cards": [
    {
      "address": "0000:01:00.0",
      "index": 0,
      "pci": {
        "driver": "nvidia",
        "address": "0000:01:00.0",
        "vendor": {
          "id": "10de",
          "name": "NVIDIA Corporation"
        },
        "product": {
          "id": "1e30",
          "name": "TU102 [Quadro RTX 6000/8000]"
        },
        "revision": "a1",
        "subsystem": {
          "id": "129e",
          "name": "NVIDIA Corporation Device"
        },
        "class": {
          "id": "03",
          "name": "Display controller"
        },
        "subclass": {
          "id": "00",
          "name": "VGA compatible controller"
        }
      }
    }
  ]
}
```
