### PR TITLE
feat(gpu): add Tesla V100 PCIe 32Gi device 1db6

### DIFF
--- a/devices/pcie/gpus.json
+++ b/devices/pcie/gpus.json
@@ -481,8 +481,12 @@
         "name": "a5000",
         "interface": "PCIe",
         "memory_size": "24Gi"
+      },
+      "1db6": {
+        "name": "v100",
+        "interface": "PCIe",
+        "memory_size": "32Gi"
       }
-      
     }
   },
   "1002": {


### PR DESCRIPTION
## Summary

This PR adds support for the NVIDIA Tesla V100 PCIe 32GB with PCI device ID `10de:1db6`.

## Background

The current GPU database already contains several Tesla V100 variants:

- 1db1 (SXM2)
- 1db5 (SXM2)
- 1db8 (SXM3)
- 1df0 (PCIe)

However, PCI ID `1db6` is currently missing.

As a result, Akash inventory cannot automatically identify Tesla V100 PCIe 32GB cards using this PCI ID, even though the hardware is correctly detected by Kubernetes and NVIDIA drivers.

This mapping has been validated on a production Akash provider using NVIDIA Tesla V100 PCIe 32GB GPUs reporting PCI device ID `10de:1db6`.

## Change

Added:

```json
"1db6": {
  "name": "v100",
  "interface": "PCIe",
  "memory_size": "32Gi"
}

